### PR TITLE
feat(custom-repo): add ability for custom repo

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_appName__",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "icons": {
@@ -26,7 +26,9 @@
         "https://bitbucket.org/*/pull-request/new*",
         "http://bitbucket.org/*/pull-request/new*",
         "https://bitbucket.org/*/pull-requests/new*",
-        "http://bitbucket.org/*/pull-requests/new*"
+        "http://bitbucket.org/*/pull-requests/new*",
+        "http://*/*/pull-request*",
+        "https://*/*/pull-request*"
       ],
       "js": [
         "scripts/contentscript.js"

--- a/app/options.html
+++ b/app/options.html
@@ -61,6 +61,40 @@
     </div>
 
     <div class="row">
+        <div class="col-xs-12">
+            <h2>Custom Repository</h2>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" id="customRepoEnabled"> Enable on your custom repository?
+                </label>
+            </div>
+        </div>
+
+        <div class="col-xs-12">
+            <div class="form-group">
+                <label for="customRepoRegex">Custom Repo Regex</label>
+                <input type="text" class="form-control" id="customRepoRegex"
+                       placeholder="enterprise-stash(.*)pull-request/new">
+            </div>
+        </div>
+
+        <div class="col-xs-12">
+            <div class="form-group">
+                <label for="customRepoDescriptionID">HTML ID of the PR Description Box</label>
+                <input type="text" class="form-control" id="customRepoDescriptionID" placeholder="id_description">
+            </div>
+        </div>
+
+        <div class="col-xs-12">
+            <div class="form-group">
+                <label for="customRepoTemplateUrl">PR Template URL</label>
+                <input type="text" class="form-control" id="customRepoTemplateUrl"
+                       placeholder="https://raw.github.com/sprintly/sprint.ly-culture/master/pr-template.md">
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
         <div class="col-xs-12 col-sm-6 col-md-4">
             <div id="save-result" class="alert alert-success hide">
                 Settings saved.

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -9,12 +9,23 @@
         var githubTemplateUrl = document.getElementById('githubTemplateUrl').value;
         var bitbucketEnabled = document.getElementById('bitbucketEnabled').checked;
         var bitbucketTemplateUrl = document.getElementById('bitbucketTemplateUrl').value;
+        
+        var customEnabled = document.getElementById('customRepoEnabled').checked;
+        var customTemplateUrl = document.getElementById('customRepoTemplateUrl').value;
+        var customRepoRegex = document.getElementById('customRepoRegex').value;
+        var customRepoDescriptionID = document.getElementById('customRepoDescriptionID').value;
 
         chrome.storage.sync.set({
             githubEnabled: githubEnabled,
             githubTemplateUrl: githubTemplateUrl ? githubTemplateUrl : defaultUrl,
             bitbucketEnabled: bitbucketEnabled,
-            bitbucketTemplateUrl: bitbucketTemplateUrl ? bitbucketTemplateUrl : defaultUrl
+            bitbucketTemplateUrl: bitbucketTemplateUrl ? bitbucketTemplateUrl : defaultUrl,
+
+            customEnabled: customEnabled,
+            customTemplateUrl: customTemplateUrl ? customTemplateUrl : defaultUrl,
+            customRepoRegex: customRepoRegex ? customRepoRegex : '',
+            customRepoDescriptionID: customRepoDescriptionID ? customRepoDescriptionID : ''
+
         }, function () {
 
             // Update status to let user know options were saved.
@@ -37,12 +48,24 @@
             githubEnabled: true,
             githubTemplateUrl: defaultUrl,
             bitbucketEnabled: true,
-            bitbucketTemplateUrl: defaultUrl
+            bitbucketTemplateUrl: defaultUrl,
+
+            customEnabled: true,
+            customTemplateUrl: defaultUrl,
+            customRepoRegex: '',
+            customRepoDescriptionID: ''
+
         }, function (items) {
             document.getElementById('githubEnabled').checked = items.githubEnabled;
             document.getElementById('githubTemplateUrl').value = items.githubTemplateUrl;
             document.getElementById('bitbucketEnabled').checked = items.bitbucketEnabled;
             document.getElementById('bitbucketTemplateUrl').value = items.githubTemplateUrl;
+            
+            document.getElementById('customRepoEnabled').checked = items.customEnabled;
+            document.getElementById('customRepoTemplateUrl').value = items.customTemplateUrl;
+            document.getElementById('customRepoRegex').value = items.customRepoRegex;
+            document.getElementById('customRepoDescriptionID').value = items.customRepoDescriptionID;
+
         });
 
     }

--- a/package.json
+++ b/package.json
@@ -1,31 +1,48 @@
 {
   "name": "git-pull-request-template",
-  "version": "0.0.0",
-  "dependencies": {},
+  "version": "0.1.6",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tcrammond/chrome-pullrequest-templates.git"
+  },
+  "bugs": {
+    "url": "https://github.com/tcrammond/chrome-pullrequest-templates/issues"
+  },
+  "dependencies": {
+    "bower": "1.7.9"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-uglify": "~0.4.0",
-    "grunt-contrib-jshint": "~0.9.2",
-    "grunt-contrib-cssmin": "~0.9.0",
-    "grunt-contrib-connect": "~0.7.1",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-htmlmin": "~0.2.0",
     "grunt-bower-install": "~1.0.0",
+    "grunt-chrome-manifest": "~0.2.0",
+    "grunt-concurrent": "~0.5.0",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-compress": "~0.9.1",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-connect": "~0.7.1",
+    "grunt-contrib-copy": "~0.5.0",
+    "grunt-contrib-cssmin": "~0.9.0",
+    "grunt-contrib-htmlmin": "~0.2.0",
     "grunt-contrib-imagemin": "~0.7.1",
+    "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-usemin": "~2.1.0",
     "grunt-mocha": "~0.4.10",
     "grunt-svgmin": "~0.4.0",
-    "grunt-concurrent": "~0.5.0",
-    "load-grunt-tasks": "~0.4.0",
-    "time-grunt": "~0.3.1",
+    "grunt-usemin": "~2.1.0",
+    "imagemin-gifsicle": "5.1.0",
+    "imagemin-jpegtran": "5.0.2",
+    "imagemin-optipng": "5.1.1",
+    "imagemin-pngquant": "5.0.0",
     "jshint-stylish": "~0.1.5",
-    "grunt-chrome-manifest": "~0.2.0",
-    "grunt-contrib-compress": "~0.9.1"
+    "load-grunt-tasks": "~0.4.0",
+    "time-grunt": "~0.3.1"
+  },
+  "scripts": {
+    "postinstall": "node_modules/.bin/bower i"
   },
   "engines": {
     "node": ">=0.8.0"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Add the ability for a user to specify a custom repository URL where the Pull Request template can be loaded. This is done by specifying the regex of the repo and the DOM element ID of the description to be populated. Demo below

This is useful for teams using the enterprise version of bitbucket or git on their own servers.

## Screenshot of Options Page 
<img width="623" alt="custom-pr-options" src="https://cloud.githubusercontent.com/assets/1434101/17470157/ac2f50b2-5cff-11e6-8c6c-5493b080491f.png">

## Gif of Custom Pull Request Page in Action
![custom-pr-template-example](https://cloud.githubusercontent.com/assets/1434101/17470158/ac31a6e6-5cff-11e6-88cd-7e555780bf3a.gif)

 