### PR TITLE
Fixes Issue 15 - Incorrect Bitbucket Template

### DIFF
--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -69,7 +69,7 @@
       document.getElementById('githubTemplateUrl').value = items.githubTemplateUrl;
       document.getElementById('githubTemplateContent').value = items.githubTemplateContent;
       document.getElementById('bitbucketEnabled').checked = items.bitbucketEnabled;
-      document.getElementById('bitbucketTemplateUrl').value = items.githubTemplateUrl;
+      document.getElementById('bitbucketTemplateUrl').value = items.bitbucketTemplateUrl;
       document.getElementById('bitbucketTemplateContent').value = items.bitbucketTemplateContent;
       document.getElementById('bitbucketOverwrite').checked = items.bitbucketOverwrite;
 


### PR DESCRIPTION
This relates to the bug ticket here: https://github.com/tcrammond/chrome-pullrequest-templates/issues/15

It looks like you're pulling the Github template from the local chrome storage rather than the bitbucket template. This will fix the issue and make sure you're pulling the correct template and updating the field rather than just showing the default.